### PR TITLE
Make HTTP version optional

### DIFF
--- a/test/integration.vim
+++ b/test/integration.vim
@@ -163,6 +163,14 @@ function! s:suite.clean_replaces_invalid_content_length_header()
   call s:assert.equal(l:contents, l:expected)
 endfunction
 
+function! s:suite.clean_appends_protocol()
+  call s:load_request_expected('simple_get_without_protocol')
+  call s:command_with_input('HttpClean', ['Y'])
+  let l:contents = getline(0, '$')
+  let l:expected = ['GET http://localhost:8000/get HTTP/1.1']
+  call s:assert.equal(l:contents, l:expected)
+endfunction
+
 " }}}
 " Auth: {{{1
 function! s:suite.auth()

--- a/test/test-http-files/simple_get_without_protocol.http
+++ b/test/test-http-files/simple_get_without_protocol.http
@@ -1,0 +1,1 @@
+GET http://localhost:8000/get


### PR DESCRIPTION
Thanks for the great plugin!

This change makes the HTTP version optional, so this format will make a valid curl request:

```http
GET http://localhost:8000/get
```
