### PR TITLE
add option to make response buffers temporary

### DIFF
--- a/autoload/http.vim
+++ b/autoload/http.vim
@@ -151,12 +151,23 @@ endfunction
 function! s:new_response_buffer(request_buffer, response) abort
     let l:request_buffer_name  = bufname(a:request_buffer)
     let l:buffer_name = fnamemodify(l:request_buffer_name, ":r") . '.response.' . localtime() . '.http'
+    if g:vim_http_tempbuffer
+      for win in range(1, winnr('$'))
+        if getwinvar(win, 'temp')
+          execute win . 'windo close'
+        endif
+      endfor
+    endif
     if g:vim_http_split_vertically
       execute 'vert new ' . l:buffer_name
     else
       execute 'new ' . l:buffer_name
     end
     set ft=http
+    if g:vim_http_tempbuffer
+      setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nonumber
+      let w:temp = 1
+    endif
 
     let l:response_lines = split(a:response, "\\(\r\n\\|\n\\)")
 

--- a/autoload/http.vim
+++ b/autoload/http.vim
@@ -152,9 +152,9 @@ function! s:new_response_buffer(request_buffer, response) abort
     let l:request_buffer_name  = bufname(a:request_buffer)
     let l:buffer_name = fnamemodify(l:request_buffer_name, ":r") . '.response.' . localtime() . '.http'
     if g:vim_http_tempbuffer
-      for win in range(1, winnr('$'))
-        if getwinvar(win, 'vim_http_tempbuffer')
           execute win . 'windo close'
+      for l:win in range(1, winnr('$'))
+        if getwinvar(l:win, 'vim_http_tempbuffer')
         endif
       endfor
     endif

--- a/autoload/http.vim
+++ b/autoload/http.vim
@@ -153,23 +153,18 @@ function! s:new_response_buffer(request_buffer, response) abort
     let l:buffer_name = fnamemodify(l:request_buffer_name, ":r") . '.response.' . localtime() . '.http'
     if g:vim_http_tempbuffer
       for win in range(1, winnr('$'))
-        if getwinvar(win, 'temp')
+        if getwinvar(win, 'vim_http_tempbuffer')
           execute win . 'windo close'
         endif
       endfor
     endif
-    " if g:vim_http_split_vertically
-    "   execute 'vert new ' . l:buffer_name
-    " else
-    "   execute 'new ' . l:buffer_name
-    " end
     let l:keepalt = g:vim_http_tempbuffer ? 'keepalt ' : ''
     let l:vert = g:vim_http_split_vertically ? 'vert ' : ''
     execute l:keepalt . l:vert . 'new ' . l:buffer_name
     set ft=http
     if g:vim_http_tempbuffer
       setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nonumber
-      let w:temp = 1
+      let w:vim_http_tempbuffer = 1
     endif
 
     let l:response_lines = split(a:response, "\\(\r\n\\|\n\\)")

--- a/autoload/http.vim
+++ b/autoload/http.vim
@@ -152,9 +152,9 @@ function! s:new_response_buffer(request_buffer, response) abort
     let l:request_buffer_name  = bufname(a:request_buffer)
     let l:buffer_name = fnamemodify(l:request_buffer_name, ":r") . '.response.' . localtime() . '.http'
     if g:vim_http_tempbuffer
-          execute win . 'windo close'
       for l:win in range(1, winnr('$'))
         if getwinvar(l:win, 'vim_http_tempbuffer')
+          execute l:win . 'windo close'
         endif
       endfor
     endif

--- a/autoload/http.vim
+++ b/autoload/http.vim
@@ -158,11 +158,14 @@ function! s:new_response_buffer(request_buffer, response) abort
         endif
       endfor
     endif
-    if g:vim_http_split_vertically
-      execute 'vert new ' . l:buffer_name
-    else
-      execute 'new ' . l:buffer_name
-    end
+    " if g:vim_http_split_vertically
+    "   execute 'vert new ' . l:buffer_name
+    " else
+    "   execute 'new ' . l:buffer_name
+    " end
+    let l:keepalt = g:vim_http_tempbuffer ? 'keepalt ' : ''
+    let l:vert = g:vim_http_split_vertically ? 'vert ' : ''
+    execute l:keepalt . l:vert . 'new ' . l:buffer_name
     set ft=http
     if g:vim_http_tempbuffer
       setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nonumber

--- a/plugin/http.vim
+++ b/plugin/http.vim
@@ -7,6 +7,9 @@ endif
 if !exists('g:vim_http_split_vertically')
   let g:vim_http_split_vertically = 0
 endif
+if !exists('g:vim_http_tempbuffer')
+  let g:vim_http_tempbuffer = 0
+endif
 
 command! -bang Http call http#do_buffer('<bang>' == '!')
 command! -bang HttpShowCurl call http#show_curl('<bang>' == '!')

--- a/test/integration.vim
+++ b/test/integration.vim
@@ -240,4 +240,20 @@ function! s:suite.set_header()
 endfunction
 " }}}
 " Misc: {{{1
+function! s:suite.tempbuffer()
+    let l:expected = filter(range(1, bufnr('$')), 'bufexists(v:val)')
+    let l:vim_http_tempbuffer = g:vim_http_tempbuffer
+    let g:vim_http_tempbuffer = 1
+
+    call s:load_request_expected('simple_get')
+    Http
+    wincmd p
+    call s:load_request_expected('get_url_params')
+    Http
+    wincmd c
+
+    let g:vim_http_tempbuffer = l:vim_http_tempbuffer
+    let l:contents = filter(range(1, bufnr('$')), 'bufexists(v:val)')
+    call s:assert.equal(l:contents, l:expected)
+endfunction
 " vim:fdm=marker

--- a/test/integration.vim
+++ b/test/integration.vim
@@ -241,19 +241,21 @@ endfunction
 " }}}
 " Misc: {{{1
 function! s:suite.tempbuffer()
-    let l:expected = filter(range(1, bufnr('$')), 'bufexists(v:val)')
     let l:vim_http_tempbuffer = g:vim_http_tempbuffer
     let g:vim_http_tempbuffer = 1
 
     call s:load_request_expected('simple_get')
-    Http
-    wincmd p
     call s:load_request_expected('get_url_params')
-    Http
-    wincmd c
+    let l:expected = filter(range(1, bufnr('$')), 'bufexists(v:val)')
 
-    let g:vim_http_tempbuffer = l:vim_http_tempbuffer
+    Http     " test get_url_params.http
+    wincmd p " switch from response window back to get_url_params.http window
+    buffer # " switch to simple_get.http buffer
+    Http     " test simple_get.http
+    wincmd c " close response window
+
     let l:contents = filter(range(1, bufnr('$')), 'bufexists(v:val)')
+    let g:vim_http_tempbuffer = l:vim_http_tempbuffer
     call s:assert.equal(l:contents, l:expected)
 endfunction
 " vim:fdm=marker


### PR DESCRIPTION
Thanks for this plugin, it's really useful to me. However, whenever I have a malformed request I don't wish to retain the response buffer, and they really pollute the buffer list!

I added an option `g:vim_http_tempbuffer` that makes all response buffers temporary so they leave no trace once their window is closed. Whenever you send a new `:Http` request, all open response windows get closed first before a new response window is opened. This makes it easy to keep tweaking the request until you get the response you want, at which you can then copy the response to another file or something to preserve the output.

[![asciicast](https://asciinema.org/a/OtJaOUovIoTMEoWirk3ww7hbs.svg)](https://asciinema.org/a/OtJaOUovIoTMEoWirk3ww7hbs)

This can be made into a toggleable On/Off thing, but I'm not sure how you'd prefer it to be implemented.