### PR TITLE
feat: add option to open split on the right side or on the bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ to curl.
 `g:vim_http_split_vertically` when set to `1` will split the window vertically
 on response rather than horizontally (the default).
 
+`g:vim_http_right_below` when set to `1` split window will be open on the
+right (for vertical) or below (for horizontal).
+
 `g:vim_http_tempbuffer` when set to `1` response buffers will overwrite each
 other instead of persisting forever.
 

--- a/autoload/http.vim
+++ b/autoload/http.vim
@@ -163,9 +163,10 @@ function! s:new_response_buffer(request_buffer, response) abort
         endif
       endfor
     endif
+    let l:rightbelow = g:vim_http_right_below ? 'rightbelow ' : ''
     let l:keepalt = g:vim_http_tempbuffer ? 'keepalt ' : ''
     let l:vert = g:vim_http_split_vertically ? 'vert ' : ''
-    execute l:keepalt . l:vert . 'new ' . l:buffer_name
+    execute l:keepalt . l:rightbelow . l:vert . 'new ' . l:buffer_name
     set ft=http
     if g:vim_http_tempbuffer
       setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nonumber

--- a/plugin/http.vim
+++ b/plugin/http.vim
@@ -7,6 +7,9 @@ endif
 if !exists('g:vim_http_split_vertically')
   let g:vim_http_split_vertically = 0
 endif
+if !exists('g:vim_http_right_below')
+  let g:vim_http_right_below = 0
+endif
 if !exists('g:vim_http_tempbuffer')
   let g:vim_http_tempbuffer = 0
 endif


### PR DESCRIPTION
I like having my split windows open on the right side when splitting vertically. This option allows for that by adding the `rightbelow` command before the split.

`g:vim_http_right_below` when set to `1` split window will be open on the
right (for vertical) or below (for horizontal).
